### PR TITLE
Update vfb_fullontologies.txt

### DIFF
--- a/config/collectdata/vfb_fullontologies.txt
+++ b/config/collectdata/vfb_fullontologies.txt
@@ -1,3 +1,4 @@
-https://raw.githubusercontent.com/obophenotype/uberon/v2021-11-28/uberon-full.owl
-https://raw.githubusercontent.com/obophenotype/cell-ontology/master/cl.owl
-https://github.com/obophenotype/ncbitaxon/releases/download/v2022-02-21/taxslim.owl
+http://purl.obolibrary.org/obo/uberon/uberon-base.owl
+http://purl.obolibrary.org/obo/cl/cl-base.owl
+http://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim.owl
+


### PR DESCRIPTION
Switching config to use PURLs, removing fixed versioning and use -base files where possible.

Current config will work OK, but this should be more sustainable. Persistent URLs will work even if we move or re-arrange repo.  Avoiding versioned  links will => us automated updates.  -base files lack imports, so will version clashes between CL & CL import to Uberon & vice versa.  The downside of -base files is that there will be many terms with no metadata, but I think these can (will) be filtered out.

Please let me know if any questions. 
