### PR TITLE
Fixed PATO prefix

### DIFF
--- a/config/dumps/sparql/construct_Disease.sparql
+++ b/config/dumps/sparql/construct_Disease.sparql
@@ -1,4 +1,4 @@
-PREFIX PATO: <http://purl.obolibrary.org/obo/>
+PREFIX PATO: <http://purl.obolibrary.org/obo/PATO_>
 
 CONSTRUCT {
 	?s <http://n2o.neo/property/nodeLabel> "Disease" .


### PR DESCRIPTION
Fixed the typo at construct_Disease.sparql. This will solve the missing Disease tag on Normal, PATO:0000461