### PR TITLE
Removed efo-base and added capo-base to ontology list

### DIFF
--- a/config/collectdata/vfb_fullontologies.txt
+++ b/config/collectdata/vfb_fullontologies.txt
@@ -2,10 +2,10 @@ http://purl.obolibrary.org/obo/uberon/uberon-base.owl
 http://purl.obolibrary.org/obo/cl/cl-base.owl
 http://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim.owl
 http://purl.obolibrary.org/obo/hancestro/hancestro.owl
-https://www.ebi.ac.uk/efo/efo-base.owl
 http://purl.obolibrary.org/obo/mondo/mondo-base.owl
 http://purl.obolibrary.org/obo/pato.owl
 https://raw.githubusercontent.com/kharchenkolab/cap_organ_slim/main/src/results/cap_organ_slim.owl
+https://raw.githubusercontent.com/kharchenkolab/cap_ontology/main/capo-base.owl
 http://purl.obolibrary.org/obo/fbbt.owl
 http://purl.obolibrary.org/obo/fbdv.owl
 http://purl.obolibrary.org/obo/wbls.owl


### PR DESCRIPTION
With the updated cap ontology with EFO/Assay terms, we no longer need efo-base ontology in the pipeline. Instead of efo-base we now use capo-base.owl.
Bradley and I decided to use base version instead of full version of the cap ontology, since we only need the newly added EFO/Assay terms alone.
We also discussed about adding cap_organ_slim ontology to the cap ontology. That would allow us to import single external ontology instead of importing those two individually. We haven't taken any action related with discussion. We will talk about it in the meeting on Monday.