### PR TITLE
PCL has been removed from ontology list

### DIFF
--- a/config/collectdata/vfb_fullontologies.txt
+++ b/config/collectdata/vfb_fullontologies.txt
@@ -6,5 +6,4 @@ http://purl.obolibrary.org/obo/mondo/mondo-base.owl
 http://purl.obolibrary.org/obo/pato.owl
 https://raw.githubusercontent.com/kharchenkolab/cap_organ_slim/main/src/results/cap_organ_slim.owl
 https://raw.githubusercontent.com/kharchenkolab/cap_ontology/main/capo-base.owl
-http://purl.obolibrary.org/obo/pcl.owl
 https://github.com/obophenotype/uberon/releases/download/v2023-12-08/composite-metazoan.owl


### PR DESCRIPTION
Fixes [MVP-5670](https://capdevelopment.atlassian.net/browse/MVP-5670)

> The Provisional Cell Ontology is a location for recording provisional definitions of cell types that are not yet widely agreed upon.  As PCL has expanded, results from it increasingly swamp out appropriate stable cell type terms in CL.  
> 
> This is bad enough that I have classified this as a bug.
> 
> Solution: add filters to remove PCL terms from this autosuggest or at least to downrank them.