### PR TITLE
Extend Ontology Pipeline with Developing Human Brain Atlas Ontology & Semantic Tags

### DIFF
--- a/config/collectdata/vfb_fullontologies.txt
+++ b/config/collectdata/vfb_fullontologies.txt
@@ -8,3 +8,4 @@ https://raw.githubusercontent.com/kharchenkolab/cap_organ_slim/main/src/results/
 https://raw.githubusercontent.com/kharchenkolab/cap_ontology/main/capo-base.owl
 http://purl.obolibrary.org/obo/mmusdv.owl
 http://purl.obolibrary.org/obo/hsapdv.owl
+https://purl.brain-bican.org/ontology/dhbao.owl

--- a/config/dumps/config.env
+++ b/config/dumps/config.env
@@ -1,5 +1,5 @@
 SPARQL_ENDPOINT=http://triplestore:8080/rdf4j-server/repositories/cap
 VFB_CONFIG=https://raw.githubusercontent.com/kharchenkolab/cap-pipeline-config/development/config/prod/neo4j2owl-config.yaml
-DUMPS_SOLR="all Species Common_species Organ Assay Sex Disease C_elegans D_melanogaster D_rerio H_sapiens M_musculus Xenopus Cell"
-DUMPS_PDB="all Species Common_species Organ Assay Sex Disease C_elegans D_melanogaster D_rerio H_sapiens M_musculus Xenopus Cell"
+DUMPS_SOLR="all Species Common_species Organ Assay Sex Disease C_elegans D_melanogaster D_rerio H_sapiens M_musculus Xenopus Cell Dhba"
+DUMPS_PDB="all Species Common_species Organ Assay Sex Disease C_elegans D_melanogaster D_rerio H_sapiens M_musculus Xenopus Cell Dhba"
 DUMPS_OWLERY="all"

--- a/config/dumps/sparql/construct_Dhba.sparql
+++ b/config/dumps/sparql/construct_Dhba.sparql
@@ -1,0 +1,9 @@
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+CONSTRUCT {
+   ?s <http://n2o.neo/property/nodeLabel> "Dhba" .
+ }
+WHERE {
+  ?s rdfs:label ?o.
+  FILTER(STRSTARTS(str(?s), "https://purl.brain-bican.org/ontology/dhbao/DHBA_"))
+}


### PR DESCRIPTION
Related with [MVP-6371](https://capdevelopment.atlassian.net/browse/MVP-6371)

This PR integrates the **Developing Human Brain Atlas (DHBA) Ontology** into the ontology pipeline and adds new semantic tags for DHBA terms to support filtering and boosting in the ontology autocomplete service.  

### **Key Changes:**  
- Added **Developing Human Brain Atlas (DHBA) Ontology** to the pipeline.  
- Introduced **semantic tags** for DHBA terms to enhance search filtering and ranking.  
- Ensured proper indexing and validation of the new ontology and tags.  


[MVP-6371]: https://capdevelopment.atlassian.net/browse/MVP-6371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ