### PR TITLE
Add new assay terms

### DIFF
--- a/config/dumps/sparql/construct_Assay.sparql
+++ b/config/dumps/sparql/construct_Assay.sparql
@@ -8,8 +8,10 @@ VALUES ?s
 {efo:EFO_0009901 #10x 3' v1
 efo:EFO_0009899 #10x 3' v2
 efo:EFO_0009922 #10x 3' v3
+efo:EFO_0030003 #10x 3' transcription profiling
 efo:EFO_0011025 #10x 5' v1
 efo:EFO_0009900 #10x 5' v2
+efo:EFO_0030004 #10x 5' transcription profiling
 efo:EFO_0030059 #10x multiome
 efo:EFO_0700006 #ExSeq
 efo:EFO_0030060 #mCT-seq


### PR DESCRIPTION
Add EFO:0030003 (10× 3′ transcription profiling) and EFO:0030004 (10× 5′ transcription profiling) as new assay terms to the config.