### PR TITLE
Bootstrap Solr Schema with Unified configure-solr.sh and Remove Outdated Scripts

### DIFF
--- a/solr_config.sh
+++ b/solr_config.sh
@@ -1,260 +1,151 @@
 #!/usr/bin/env bash
 #
-# This script updates ontology schema with ngram based new search fields. These new text fields has naming: *_autosuggest_e
-# and *_autosuggest_wse, and enable partial matching capability. To run this script, your solr should be up and running
-# and the latest dump file, solr.json, is uploaded.
+# Consolidated Solr Schema API script for fresh instance
+# - Parse flags for host, port, and collection
+# - Index CL_4023041 document
+# - Define final field types (textEdge, textShingleEdge, nameExact, textStart)
+# - Add autosuggest fields & copy-fields for label and synonym_* metadata
+# - Clear all docs at the end
 #
-# Important: After the schema change, reindexing is required. For this purpose, you can simply re-upload the dump data
-# to the ontology collection.
-#
-# Usage:
-# bash solr_post_config.sh -h localhost -p 8993
+# Consult https://solr.apache.org/guide/8_11/schema-api.html for details
 
 set -e
 
+# Parse command-line options for host (-h), port (-p), collection (-c)
+while getopts h:p:c: flag; do
+  case "${flag}" in
+    h) host=${OPTARG};;
+    p) port=${OPTARG};;
+    c) collection=${OPTARG};;
+    *) echo "!!! Invalid flag. Only -h, -p, and -c are supported." && exit 1;;
+  esac
+done
+
+# Validate required flags
+[[ -z "$host"      ]] && echo "ERROR: host (-h) must be provided!"      && exit 1
+[[ -z "$port"      ]] && echo "ERROR: port (-p) must be provided!"      && exit 1
+[[ -z "$collection" ]] && echo "ERROR: collection (-c) must be provided!" && exit 1
+
+BASE_URL="http://$host:$port/solr"
+SCHEMA_URL="$BASE_URL/$collection/schema"
+
+# 1) Index only the CL_4023041 document
+echo "=== Indexing CL_4023041 document ==="
+curl --location --request POST "$BASE_URL/$collection/update/json?commit=true" \
+     --header 'Content-Type: application/json' \
+     --data '[{"definition":["A glutamatergic neuron, with a soma found in the deeper portion of L5, that has long-range axonal .."],"facets_annotation":["Class","brain","Animal_cell"],"id":"http://purl.obolibrary.org/obo/CL_4023041","iri":["http://purl.obolibrary.org/obo/CL_4023041"],"label":["L5 extratelencephalic projecting glutamatergic cortical neuron"],"obo_id":["CL:4023041"],"short_form":["CL_4023041"],"synonym":["burst-firing layer 5 neuron","pyramidal tract (PT) neuron","L5 extratelencephalic projecting glutamatergic cortical neuron","thick-tufted layer 5 (TTL5) pyramidal neuron","L5b neuron","subcerebral projection (SCPN) neuron","Pyramidal tract-like (PT-l)"],"synonym_hasRelatedSynonym":["L5b neuron","subcerebral projection (SCPN) neuron"],"synonym_hasExactSynonym":["Pyramidal tract-like (PT-l)","burst-firing layer 5 neuron","thick-tufted layer 5 (TTL5) pyramidal neuron"],"synonym_hasNarrowSynonym":["pyramidal tract (PT) neuron"]}]'
+
+echo
+# 2) Define final field types
+echo "=== Defining field types ==="
+
+# 2.a) textEdge (with EnglishMinimalStemFilterFactory)
+echo "- add-field-type textEdge"
+curl -X POST -H 'Content-type:application/json' --data-binary '{
+  "add-field-type":{
+    "name":"textEdge",
+    "class":"solr.TextField",
+    "indexAnalyzer":{
+      "tokenizer":{"class":"solr.StandardTokenizerFactory"},
+      "filters":[
+        {"class":"solr.WordDelimiterGraphFilterFactory","splitOnCaseChange":"0"},
+        {"class":"solr.LowerCaseFilterFactory"},
+        {"class":"solr.EdgeNGramFilterFactory","minGramSize":"2","maxGramSize":"35"}
+      ]
+    },
+    "queryAnalyzer":{
+      "tokenizer":{"class":"solr.WhitespaceTokenizerFactory"},
+      "filters":[
+        {"class":"solr.WordDelimiterGraphFilterFactory","splitOnCaseChange":"0"},
+        {"class":"solr.EnglishMinimalStemFilterFactory"},
+        {"class":"solr.LowerCaseFilterFactory"}
+      ]
+    }
+  }
+}' $SCHEMA_URL
+
+# 2.b) textShingleEdge
+echo "- add-field-type textShingleEdge"
+curl -X POST -H 'Content-type:application/json' --data-binary '{
+  "add-field-type":{
+    "name":"textShingleEdge",
+    "class":"solr.TextField",
+    "indexAnalyzer":{
+      "tokenizer":{"class":"solr.StandardTokenizerFactory"},
+      "filters":[
+        {"class":"solr.ShingleFilterFactory","maxShingleSize":"4","outputUnigrams":"false"},
+        {"class":"solr.LowerCaseFilterFactory"},
+        {"class":"solr.RemoveDuplicatesTokenFilterFactory"}
+      ]
+    },
+    "queryAnalyzer":{
+      "tokenizer":{"class":"solr.KeywordTokenizerFactory"},
+      "filters":[
+        {"class":"solr.LowerCaseFilterFactory"},
+        {"class":"solr.RemoveDuplicatesTokenFilterFactory"}
+      ]
+    }
+  }
+}' $SCHEMA_URL
+
+# 2.c) nameExact
+echo "- add-field-type nameExact"
+curl -X POST -H 'Content-type:application/json' --data-binary '{
+  "add-field-type":{
+    "name":"nameExact",
+    "class":"solr.TextField",
+    "indexAnalyzer":{"tokenizer":{"class":"solr.KeywordTokenizerFactory"},"filters":[{"class":"solr.LowerCaseFilterFactory"},{"class":"solr.RemoveDuplicatesTokenFilterFactory"}]},
+    "queryAnalyzer":{"tokenizer":{"class":"solr.KeywordTokenizerFactory"},"filters":[{"class":"solr.LowerCaseFilterFactory"},{"class":"solr.RemoveDuplicatesTokenFilterFactory"}]}
+  }
+}' $SCHEMA_URL
+
+# 2.d) textStart
+echo "- add-field-type textStart"
+curl -X POST -H 'Content-type:application/json' --data-binary '{
+  "add-field-type":{
+    "name":"textStart",
+    "class":"solr.TextField",
+    "indexAnalyzer":{
+      "tokenizer":{"class":"solr.KeywordTokenizerFactory"},
+      "filters":[{"class":"solr.LowerCaseFilterFactory"},{"class":"solr.RemoveDuplicatesTokenFilterFactory"},{"class":"solr.EdgeNGramFilterFactory","minGramSize":"3","maxGramSize":"35"}]
+    },
+    "queryAnalyzer":{"tokenizer":{"class":"solr.KeywordTokenizerFactory"},"filters":[{"class":"solr.LowerCaseFilterFactory"},{"class":"solr.RemoveDuplicatesTokenFilterFactory"}]}
+  }
+}' $SCHEMA_URL
+
+echo
+# 3) Add autosuggest fields & copy-field rules
+echo "=== Adding autosuggest fields & copy-field rules ==="
+
 autocomplete_single_val_fields=(label)
-autocomplete_multi_val_fields=(synonym facets_annotation)
+autocomplete_multi_val_fields=(synonym_hasExactSynonym synonym_hasNarrowSynonym synonym_hasRelatedSynonym)
 
-autocomplete_fields=("${autocomplete_single_val_fields[@]}" "${autocomplete_multi_val_fields[@]}")
-
-while getopts h:p:c: flag
-do
-    case "${flag}" in
-        h) host=${OPTARG};;
-        p) port=${OPTARG};;
-        c) collection=${OPTARG};;
-        *) echo "!!! Invalid flag. Only -h and -p flags are supported."
-    esac
+for src in "${autocomplete_single_val_fields[@]}"; do
+  for variant in e se ne ts; do
+    declare -A type_map=( [e]=textEdge [se]=textShingleEdge [ne]=nameExact [ts]=textStart )
+    echo "- add-field ${src}_autosuggest_${variant}"
+    curl -X POST -H 'Content-type:application/json' --data-binary "{\"add-field\":{\"name\":\"${src}_autosuggest_${variant}\",\"type\":\"${type_map[$variant]}\",\"indexed\":true,\"stored\":true,\"multiValued\":false}}" $SCHEMA_URL
+    echo "- add-copy-field ${src} → ${src}_autosuggest_${variant}"
+    curl -X POST -H 'Content-type:application/json' --data-binary "{\"add-copy-field\":{\"source\":\"${src}\",\"dest\":\"${src}_autosuggest_${variant}\"}}" $SCHEMA_URL
+  done
 done
 
-echo "Updating $collection in server $host:$port"
-
-echo "Adding textEdge field type"
-curl -X POST -H 'Content-type:application/json' --data-binary "{
-  \"add-field-type\":{
-    \"name\":\"textEdge\",
-    \"class\":\"solr.TextField\",
-    \"indexAnalyzer\":{
-      \"tokenizer\":{
-         \"class\":\"solr.PatternTokenizerFactory\",
-         \"pattern\":\"______\" },
-       \"filters\":[{\"class\":\"solr.LowerCaseFilterFactory\" },
-                   {\"class\":\"solr.RemoveDuplicatesTokenFilterFactory\" },
-                   {\"class\":\"solr.EdgeNGramFilterFactory\",
-                   \"minGramSize\":\"3\",
-                   \"maxGramSize\":\"35\"}]
-    },
-    \"queryAnalyzer\":{
-      \"tokenizer\":{
-         \"class\":\"solr.PatternTokenizerFactory\",
-         \"pattern\":\"______\" },
-       \"filters\":[{\"class\":\"solr.LowerCaseFilterFactory\" },
-                   {\"class\":\"solr.RemoveDuplicatesTokenFilterFactory\" }]
-    }
-  }
-}" http://$host:$port/solr/$collection/schema --show-error --fail
-
-echo "Adding textWhitespaceEdge field type"
-curl -X POST -H 'Content-type:application/json' --data-binary "{
-  \"add-field-type\":{
-    \"name\":\"textWhitespaceEdge\",
-    \"class\":\"solr.TextField\",
-    \"indexAnalyzer\":{
-      \"tokenizer\":{
-         \"class\":\"solr.WhitespaceTokenizerFactory\" },
-       \"filters\":[{\"class\":\"solr.LowerCaseFilterFactory\" },
-                   {\"class\":\"solr.RemoveDuplicatesTokenFilterFactory\" },
-                   {\"class\":\"solr.EdgeNGramFilterFactory\",
-                   \"minGramSize\":\"3\",
-                   \"maxGramSize\":\"35\"}]
-    },
-    \"queryAnalyzer\":{
-      \"tokenizer\":{
-         \"class\":\"solr.WhitespaceTokenizerFactory\" },
-       \"filters\":[{\"class\":\"solr.LowerCaseFilterFactory\" },
-                   {\"class\":\"solr.RemoveDuplicatesTokenFilterFactory\" }]
-    }
-  }
-}" http://$host:$port/solr/$collection/schema --show-error --fail
-
-echo "Adding textCustomEdge field type"
-curl -X POST -H 'Content-type:application/json' --data-binary "{
-  \"add-field-type\":{
-    \"name\":\"textCustomEdge\",
-    \"class\":\"solr.TextField\",
-    \"indexAnalyzer\":{
-      \"tokenizer\":{
-         \"class\":\"solr.PatternTokenizerFactory\",
-         \"pattern\":\"[-–_ ]\" },
-       \"filters\":[{\"class\":\"solr.WordDelimiterGraphFilterFactory\",
-                    \"generateNumberParts\":\"0\"},
-                   {\"class\":\"solr.RemoveDuplicatesTokenFilterFactory\"},
-                   {\"class\":\"solr.LowerCaseFilterFactory\"},
-                   {\"class\":\"solr.EdgeNGramFilterFactory\",
-                   \"minGramSize\":\"3\",
-                   \"maxGramSize\":\"35\"}]
-    },
-    \"queryAnalyzer\":{
-      \"tokenizer\":{
-         \"class\":\"solr.PatternTokenizerFactory\",
-         \"pattern\":\"[-–_ ]\" },
-       \"filters\":[{\"class\":\"solr.LowerCaseFilterFactory\" },
-                   {\"class\":\"solr.RemoveDuplicatesTokenFilterFactory\" }]
-    }
-  }
-}" http://$host:$port/solr/$collection/schema --show-error --fail
-
-echo "Adding nameExact field type"
-curl -X POST -H 'Content-type:application/json' --data-binary "{
-  \"add-field-type\":{
-    \"name\":\"nameExact\",
-    \"class\":\"solr.TextField\",
-    \"indexAnalyzer\":{
-      \"tokenizer\":{
-         \"class\":\"solr.KeywordTokenizerFactory\"},
-       \"filters\":[{\"class\":\"solr.LowerCaseFilterFactory\" },
-                   {\"class\":\"solr.RemoveDuplicatesTokenFilterFactory\"}]
-    },
-    \"queryAnalyzer\":{
-      \"tokenizer\":{
-         \"class\":\"solr.WhitespaceTokenizerFactory\" },
-       \"filters\":[{\"class\":\"solr.LowerCaseFilterFactory\" },
-                   {\"class\":\"solr.RemoveDuplicatesTokenFilterFactory\" }]
-    }
-  }
-}" http://$host:$port/solr/$collection/schema --show-error --fail
-
-echo "Adding auto complete single value fields: ${autocomplete_single_val_fields[*]}"
-for field in "${autocomplete_single_val_fields[@]}"; do
-
-  echo "Adding auto complete field e: ${field}"
-  curl -X POST -H 'Content-type:application/json' --data-binary "{
-    \"add-field\":{
-       \"name\":\"${field}_autosuggest_e\",
-       \"type\":\"textEdge\",
-       \"indexed\":true,
-       \"stored\":true,
-       \"multiValued\":false
-     }
-  }" http://$host:$port/solr/$collection/schema --show-error --fail
-
-  echo "Adding auto complete field wse: ${field}"
-  curl -X POST -H 'Content-type:application/json' --data-binary "{
-    \"add-field\":{
-       \"name\":\"${field}_autosuggest_wse\",
-       \"type\":\"textWhitespaceEdge\",
-       \"indexed\":true,
-       \"stored\":true,
-       \"multiValued\":false
-     }
-  }" http://$host:$port/solr/$collection/schema --show-error --fail
-
-  echo "Adding auto complete field ce: ${field}"
-  curl -X POST -H 'Content-type:application/json' --data-binary "{
-    \"add-field\":{
-       \"name\":\"${field}_autosuggest_ce\",
-       \"type\":\"textCustomEdge\",
-       \"indexed\":true,
-       \"stored\":true,
-       \"multiValued\":false
-     }
-  }" http://$host:$port/solr/$collection/schema --show-error --fail
-
-  echo "Adding auto complete field ne: ${field}"
-  curl -X POST -H 'Content-type:application/json' --data-binary "{
-    \"add-field\":{
-       \"name\":\"${field}_autosuggest_ne\",
-       \"type\":\"nameExact\",
-       \"indexed\":true,
-       \"stored\":true,
-       \"multiValued\":false
-     }
-  }" http://$host:$port/solr/$collection/schema --show-error --fail
-
+for src in "${autocomplete_multi_val_fields[@]}"; do
+  for variant in e se ne ts; do
+    declare -A type_map=( [e]=textEdge [se]=textShingleEdge [ne]=nameExact [ts]=textStart )
+    echo "- add-field ${src}_autosuggest_${variant}"
+    curl -X POST -H 'Content-type:application/json' --data-binary "{\"add-field\":{\"name\":\"${src}_autosuggest_${variant}\",\"type\":\"${type_map[$variant]}\",\"indexed\":true,\"stored\":true,\"multiValued\":true}}" $SCHEMA_URL
+    echo "- add-copy-field ${src} → ${src}_autosuggest_${variant}"
+    curl -X POST -H 'Content-type:application/json' --data-binary "{\"add-copy-field\":{\"source\":\"${src}\",\"dest\":\"${src}_autosuggest_${variant}\"}}" $SCHEMA_URL
+  done
 done
 
-echo "Adding auto complete multi value fields: ${autocomplete_multi_val_fields[*]}"
-for field in "${autocomplete_multi_val_fields[@]}"; do
+echo
+# 4) Clear all docs at end
+echo "=== Final Step: Clear all docs ==="
+curl -X POST -H 'Content-Type: application/json' \
+     "$BASE_URL/$collection/update?commit=true" \
+     -d '{ "delete": {"query":"*:*"} }'
 
-  echo "Adding auto complete field e: ${field}"
-  curl -X POST -H 'Content-type:application/json' --data-binary "{
-    \"add-field\":{
-       \"name\":\"${field}_autosuggest_e\",
-       \"type\":\"textEdge\",
-       \"indexed\":true,
-       \"stored\":true,
-       \"multiValued\":true
-     }
-  }" http://$host:$port/solr/$collection/schema --show-error --fail
+echo "Solr schema configuration complete."
 
-
-  echo "Adding auto complete field wse: ${field}"
-  curl -X POST -H 'Content-type:application/json' --data-binary "{
-    \"add-field\":{
-       \"name\":\"${field}_autosuggest_wse\",
-       \"type\":\"textWhitespaceEdge\",
-       \"indexed\":true,
-       \"stored\":true,
-       \"multiValued\":true
-     }
-  }" http://$host:$port/solr/$collection/schema --show-error --fail
-
-  echo "Adding auto complete field ce: ${field}"
-  curl -X POST -H 'Content-type:application/json' --data-binary "{
-    \"add-field\":{
-       \"name\":\"${field}_autosuggest_ce\",
-       \"type\":\"textCustomEdge\",
-       \"indexed\":true,
-       \"stored\":true,
-       \"multiValued\":true
-     }
-  }" http://$host:$port/solr/$collection/schema --show-error --fail
-
-  echo "Adding auto complete field ne: ${field}"
-  curl -X POST -H 'Content-type:application/json' --data-binary "{
-    \"add-field\":{
-       \"name\":\"${field}_autosuggest_ne\",
-       \"type\":\"nameExact\",
-       \"indexed\":true,
-       \"stored\":true,
-       \"multiValued\":true
-     }
-  }" http://$host:$port/solr/$collection/schema --show-error --fail
-
-done
-
-echo "Copying auto complete fields: ${autocomplete_fields[*]}"
-for field in "${autocomplete_fields[@]}"; do
-
-  echo "Copying auto complete field e: ${field}"
-  curl -X POST -H 'Content-type:application/json' --data-binary "{
-    \"add-copy-field\":{
-    \"source\":\"${field}\",
-    \"dest\":\"${field}_autosuggest_e\"}
-  }" http://$host:$port/solr/$collection/schema --show-error --fail
-
-  echo "Copying auto complete field wse: ${field}"
-  curl -X POST -H 'Content-type:application/json' --data-binary "{
-    \"add-copy-field\":{
-    \"source\":\"${field}\",
-    \"dest\":\"${field}_autosuggest_wse\"}
-  }" http://$host:$port/solr/$collection/schema --show-error --fail
-
-  echo "Copying auto complete field ce: ${field}"
-  curl -X POST -H 'Content-type:application/json' --data-binary "{
-    \"add-copy-field\":{
-    \"source\":\"${field}\",
-    \"dest\":\"${field}_autosuggest_ce\"}
-  }" http://$host:$port/solr/$collection/schema --show-error --fail
-
-  echo "Copying auto complete field ne: ${field}"
-  curl -X POST -H 'Content-type:application/json' --data-binary "{
-    \"add-copy-field\":{
-    \"source\":\"${field}\",
-    \"dest\":\"${field}_autosuggest_ne\"}
-  }" http://$host:$port/solr/$collection/schema --show-error --fail
-
-done
-
-echo "successfully finished configuring solr schema with the Schema API."
-echo "SUCCESS"


### PR DESCRIPTION
Related with [MVP-6743](https://capdevelopment.atlassian.net/browse/MVP-6743)

This PR replaces our previous series of incremental Solr configuration scripts with a single, consolidated `configure-solr.sh` and removes all outdated versions. Key changes:

1. **New bootstrap script**:
   - Parses `-h`, `-p`, `-c` flags instead of env vars
   - Indexes only the CL_4023041 document
   - Defines field types: `textEdge` (with stemmer), `textShingleEdge`, `nameExact`, `textStart`
   - Adds autosuggest plumbing for `label` and synonym_* metadata fields
   - Clears all docs at the end

2. **Cleanup**:
   - Deletes all legacy `.sh` files formerly used for piecemeal schema updates
   - Updates `README.md` with usage instructions for the new script

3. **Verification**:
   - Successfully tested on a fresh Solr 8.11 instance:
     ```bash
     ./solr_config.sh -h localhost -p 8983 -c my_collection
     ```
   - Schema and `_autosuggest_*` fields verified via Solr Admin UI


[MVP-6743]: https://capdevelopment.atlassian.net/browse/MVP-6743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ